### PR TITLE
Bump version to 0.5.2; ensure profiles dir exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PyZ-Launcher"
-version = "0.5.1"
+version = "0.5.2"
 description = ""
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/modules/app_config.py
+++ b/src/modules/app_config.py
@@ -11,7 +11,7 @@ import pathlib
 import platform
 
 app_name = "PyZ Launcher"
-app_version = "v0.5.1-alpha" # Enter 'dev' in the name to test
+app_version = "v0.5.2-alpha" # Enter 'dev' in the name to test
 dev_mode = True if "dev" in app_version else False
 
 SETTINGS_KEY = "pyz.minecraftlauncher.settings"

--- a/src/update/version_info.txt
+++ b/src/update/version_info.txt
@@ -6,8 +6,8 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers must be a tuple of four items: (1, 2, 3, 4)
-    filevers=(0, 5, 1, 0),
-    prodvers=(0, 5, 1, 0),
+    filevers=(0, 5, 2, 0),
+    prodvers=(0, 5, 2, 0),
     # Contains a bitmask that specifies the valid bits 'flags'
     mask=0x3f,
     # Contains a bitmask that specifies the attributes of the file
@@ -28,12 +28,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'PyZ Launcher'),
         StringStruct(u'FileDescription', u'Updater for PyZ Launcher'),
-        StringStruct(u'FileVersion', u'0.5.1'),
+        StringStruct(u'FileVersion', u'0.5.2'),
         StringStruct(u'InternalName', u'updater'),
         StringStruct(u'LegalCopyright', u'Copyright (C) 2026 by Zadkiel Avendano'),
         StringStruct(u'OriginalFilename', u'updater.exe'),
         StringStruct(u'ProductName', u'PyZ Launcher'),
-        StringStruct(u'ProductVersion', u'0.5.1')])
+        StringStruct(u'ProductVersion', u'0.5.2')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/src/views/launcher_profiles_view.py
+++ b/src/views/launcher_profiles_view.py
@@ -402,23 +402,28 @@ class LauncherProfilesView():
         If none exist, it creates default profiles and ensures the launcher_profiles.json file is present.
         """
         # Vanilla Launcher Profiles
-        if mll.vanilla_launcher.do_vanilla_launcher_profiles_exists(app_settings.return_mc_directory()):
-            self.view.controls = []
-            for profile in mll.vanilla_launcher.load_vanilla_launcher_profiles(app_settings.return_mc_directory()):
-                self.view.controls.append(LauncherProfileOption(launcher_profile=profile, on_play=lambda p: self.play_launcher_profile(launcher_profile=p),
-                                                                on_edit=lambda p: self.edit_launcher_profile(edit_profile=p),
-                                                                on_remove=lambda p, o: self.remove_launcher_profile(edit_profile=p, launcher_option=o)))
-            self.view.controls.append(self.new_launcher_profile_button)
-        else:
-            # Add the default profiles ["latest-release", "latest-snapshot"]
-            default_profiles: list[mll.types.VanillaLauncherProfile] = [
-                {"name": "", "versionType": "latest-release"},
-                {"name": "", "versionType": "latest-snapshot"}
-            ]
-            # Create launcher_profiles.json file if it doesn't exist
-            mll.vanilla_launcher.create_empty_vanilla_launcher_profiles_file(minecraft_directory=app_settings.return_mc_directory())
+        try:
+            if not os.path.exists(app_settings.return_mc_directory()):
+                os.makedirs(app_settings.return_mc_directory())
+            if mll.vanilla_launcher.do_vanilla_launcher_profiles_exists(app_settings.return_mc_directory()):
+                self.view.controls = []
+                for profile in mll.vanilla_launcher.load_vanilla_launcher_profiles(app_settings.return_mc_directory()):
+                    self.view.controls.append(LauncherProfileOption(launcher_profile=profile, on_play=lambda p: self.play_launcher_profile(launcher_profile=p),
+                                                                    on_edit=lambda p: self.edit_launcher_profile(edit_profile=p),
+                                                                    on_remove=lambda p, o: self.remove_launcher_profile(edit_profile=p, launcher_option=o)))
+                self.view.controls.append(self.new_launcher_profile_button)
+            else:
+                # Add the default profiles ["latest-release", "latest-snapshot"]
+                default_profiles: list[mll.types.VanillaLauncherProfile] = [
+                    {"name": "", "versionType": "latest-release"},
+                    {"name": "", "versionType": "latest-snapshot"}
+                ]
+                # Create launcher_profiles.json file if it doesn't exist
+                mll.vanilla_launcher.create_empty_vanilla_launcher_profiles_file(minecraft_directory=app_settings.return_mc_directory())
 
-            # Add default profiles
-            for profile in default_profiles:
-                mll.vanilla_launcher.add_vanilla_launcher_profile(app_settings.return_mc_directory(), profile)
-            refresh()
+                # Add default profiles
+                for profile in default_profiles:
+                    mll.vanilla_launcher.add_vanilla_launcher_profile(app_settings.return_mc_directory(), profile)
+                refresh()
+        except Exception as e:
+            self.page.error(message=f"Error: {e}")


### PR DESCRIPTION
Update project/app version to 0.5.2 across pyproject.toml and app_config. Update Windows updater version_info to reflect 0.5.2 (file/prod vers and file/product version strings). Improve launcher_profiles_view by creating the Minecraft directory if it doesn't exist and wrapping profile loading/creation in a try/except to surface errors via page.error, ensuring default launcher profiles are created when needed.